### PR TITLE
Change --type vuln to --type https://cosign.sigstore.dev/attestation/vuln/v1

### DIFF
--- a/policies/templates/attestations/README.md
+++ b/policies/templates/attestations/README.md
@@ -8,11 +8,11 @@ To generate a cosign vulnerability scan record, you can use Trivy and use Cosign
 
 ```shell
 trivy image --format cosign-vuln --output vuln.json <IMAGE>
-cosign attest --key /path/to/cosign.key --type vuln --predicate vuln.json <IMAGE>
+cosign attest --key /path/to/cosign.key --type https://cosign.sigstore.dev/attestation/vuln/v1 --predicate vuln.json <IMAGE>
 ```
 
 You can verify the attestation has been attached to the image:
 
 ```shell
-cosign verify-attestation --key /path/to/cosign.pub --type vuln <IMAGE>
+cosign verify-attestation --key /path/to/cosign.pub --type https://cosign.sigstore.dev/attestation/vuln/v1 <IMAGE>
 ```

--- a/policies/templates/attestations/vuln/must-have-vuln-cue.yaml
+++ b/policies/templates/attestations/vuln/must-have-vuln-cue.yaml
@@ -4,9 +4,9 @@
 #############################################################################################
 # To generate an attestation with a scan report and attest it to an image follow these steps:
 # $ trivy image --format cosign-vuln --output vuln.json <IMAGE>
-# $ cosign attest --key /path/to/cosign.key --type vuln --predicate vuln.json <IMAGE>
+# $ cosign attest --key /path/to/cosign.key --type https://cosign.sigstore.dev/attestation/vuln/v1 --predicate vuln.json <IMAGE>
 #
-# $ cosign verify-attestation --key /path/to/cosign.pub --type vuln <IMAGE>
+# $ cosign verify-attestation --key /path/to/cosign.pub --type https://cosign.sigstore.dev/attestation/vuln/v1 <IMAGE>
 #############################################################################################
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy

--- a/policies/templates/attestations/vuln/must-have-vuln-rego.yaml
+++ b/policies/templates/attestations/vuln/must-have-vuln-rego.yaml
@@ -4,9 +4,9 @@
 #############################################################################################
 # To generate an attestation with a scan report and attest it to an image follow these steps:
 # $ trivy image --format cosign-vuln --output vuln.json <IMAGE>
-# $ cosign attest --key /path/to/cosign.key --type vuln --predicate vuln.json <IMAGE>
+# $ cosign attest --key /path/to/cosign.key --type https://cosign.sigstore.dev/attestation/vuln/v1 --predicate vuln.json <IMAGE>
 #
-# $ cosign verify-attestation --key /path/to/cosign.pub --type vuln <IMAGE>
+# $ cosign verify-attestation --key /path/to/cosign.pub --type https://cosign.sigstore.dev/attestation/vuln/v1 <IMAGE>
 #############################################################################################
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy

--- a/policies/templates/attestations/vuln/vuln-error-message-rego.yaml
+++ b/policies/templates/attestations/vuln/vuln-error-message-rego.yaml
@@ -4,9 +4,9 @@
 #############################################################################################
 # To generate an attestation with a scan report and attest it to an image follow these steps:
 # $ trivy image --format cosign-vuln --output vuln.json <IMAGE>
-# $ cosign attest --key /path/to/cosign.key --type vuln --predicate vuln.json <IMAGE>
+# $ cosign attest --key /path/to/cosign.key --type https://cosign.sigstore.dev/attestation/vuln/v1 --predicate vuln.json <IMAGE>
 #
-# $ cosign verify-attestation --key /path/to/cosign.pub --type vuln <IMAGE>
+# $ cosign verify-attestation --key /path/to/cosign.pub --type https://cosign.sigstore.dev/attestation/vuln/v1 <IMAGE>
 #############################################################################################
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy

--- a/policies/templates/attestations/vuln/vuln-no-high-or-critical-rego.yaml
+++ b/policies/templates/attestations/vuln/vuln-no-high-or-critical-rego.yaml
@@ -4,9 +4,9 @@
 #############################################################################################
 # To generate an attestation with a scan report and attest it to an image follow these steps:
 # $ trivy image --format cosign-vuln --output vuln.json <IMAGE>
-# $ cosign attest --key /path/to/cosign.key --type vuln --predicate vuln.json <IMAGE>
+# $ cosign attest --key /path/to/cosign.key --type https://cosign.sigstore.dev/attestation/vuln/v1 --predicate vuln.json <IMAGE>
 #
-# $ cosign verify-attestation --key /path/to/cosign.pub --type vuln <IMAGE>
+# $ cosign verify-attestation --key /path/to/cosign.pub --type https://cosign.sigstore.dev/attestation/vuln/v1 <IMAGE>
 #############################################################################################
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy

--- a/policies/templates/attestations/vuln/vuln-warning-message-rego.yaml
+++ b/policies/templates/attestations/vuln/vuln-warning-message-rego.yaml
@@ -4,9 +4,9 @@
 #############################################################################################
 # To generate an attestation with a scan report and attest it to an image follow these steps:
 # $ trivy image --format cosign-vuln --output vuln.json <IMAGE>
-# $ cosign attest --key /path/to/cosign.key --type vuln --predicate vuln.json <IMAGE>
+# $ cosign attest --key /path/to/cosign.key --type https://cosign.sigstore.dev/attestation/vuln/v1 --predicate vuln.json <IMAGE>
 #
-# $ cosign verify-attestation --key /path/to/cosign.pub --type vuln <IMAGE>
+# $ cosign verify-attestation --key /path/to/cosign.pub --type https://cosign.sigstore.dev/attestation/vuln/v1 <IMAGE>
 #############################################################################################
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy


### PR DESCRIPTION
Drop usage of short codes and use full URLs.