### PR TITLE
Add more image support for flux

### DIFF
--- a/policies/sigstore-landscape/flux-signed.yaml
+++ b/policies/sigstore-landscape/flux-signed.yaml
@@ -14,12 +14,12 @@ metadata:
     catalog.chainguard.dev/labels: components
 spec:
   images:
-  - glob: ghcr.io/fluxcd/source-controller*
+  - glob: ghcr.io/fluxcd/*
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
       identities:
       - issuer: https://token.actions.githubusercontent.com
-        subjectRegExp: https://github\.com/fluxcd/source-controller/\.github/workflows/release\.yml@refs/tags/v.*
+        subjectRegExp: https://github\.com/fluxcd/.*/\.github/workflows/release\.yml@refs/tags/v.*
     ctlog:
       url: https://rekor.sigstore.dev

--- a/policies/sigstore-landscape/policies_test.go
+++ b/policies/sigstore-landscape/policies_test.go
@@ -136,9 +136,24 @@ func TestPolicies(t *testing.T) {
 		image:  "index.docker.io/cilium/cilium:v1.12.4",
 		check:  All(NoWarnings, CheckError("no matching signatures")),
 	}, {
-		name:   "Flux source-controller is signed",
+		name:   "Flux source-controller is signed (helm)",
 		policy: "flux-signed.yaml",
-		image:  "ghcr.io/fluxcd/source-controller:v0.32.1",
+		image:  "ghcr.io/fluxcd/helm-controller:v0.31.2",
+		check:  All(NoWarnings, NoErrors),
+	}, {
+		name:   "Flux source-controller is signed (kustomzise)",
+		policy: "flux-signed.yaml",
+		image:  "ghcr.io/fluxcd/kustomize-controller:v0.35.1",
+		check:  All(NoWarnings, NoErrors),
+	}, {
+		name:   "Flux source-controller is signed (source)",
+		policy: "flux-signed.yaml",
+		image:  "ghcr.io/fluxcd/source-controller:v0.36.1",
+		check:  All(NoWarnings, NoErrors),
+	}, {
+		name:   "Flux source-controller is signed (notification)",
+		policy: "flux-signed.yaml",
+		image:  "ghcr.io/fluxcd/notification-controller:v0.32.1",
 		check:  All(NoWarnings, NoErrors),
 	}, {
 		name:   "Kyverno is signed",


### PR DESCRIPTION
the current policy didn't allow for any other images through, such as
- helm controller
- kustomize controller
- notification controller