### PR TITLE
Fix: Make our agent policy cover tagged chainctl

### DIFF
--- a/policies/vendors/chainguard/chainguard-enforce-agent-signed.yaml
+++ b/policies/vendors/chainguard/chainguard-enforce-agent-signed.yaml
@@ -17,6 +17,10 @@ spec:
         url: https://rekor.sigstore.dev
       keyless:
         identities:
+          # This applies to the agent images (including the chainctl sidecar)
           - issuer: https://token.actions.githubusercontent.com
             subjectRegExp: https://github\.com/chainguard-dev/mono/\.github/workflows/\.build-drop\.yaml@refs/tags/v.*
+          # This applies to the standalone chainctl image we release (with our version tags).
+          - issuer: https://token.actions.githubusercontent.com
+            subjectRegExp: https://github\.com/chainguard-dev/mono/\.github/workflows/\.release-drop\.yaml@refs/tags/v.*
         url: https://fulcio.sigstore.dev

--- a/policies/vendors/chainguard/policies_test.go
+++ b/policies/vendors/chainguard/policies_test.go
@@ -54,6 +54,11 @@ func TestPolicies(t *testing.T) {
 		policy: "chainguard-enforce-agent-signed.yaml",
 		image:  "us.gcr.io/prod-enforce-fabc/controlplane@sha256:25ab95c63c7148dd7ba5d8de82abcc67a9fea9e9d2be74bb675a75f4f31e3762",
 		check:  All(NoErrors, NoWarnings),
+	}, {
+		name:   "tagged chainctl is signed",
+		policy: "chainguard-enforce-agent-signed.yaml",
+		image:  "us.gcr.io/prod-enforce-fabc/chainctl:v0.1.117",
+		check:  All(NoErrors, NoWarnings),
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
:bug: The existing policy rejects our tagged chainctl images, which are built via a separate workflow.

/kind bug