### PR TITLE
Remove TODO from `chainguard-images-attested-cue.yaml`

### DIFF
--- a/policies/vendors/chainguard/chainguard-images-attested-cue.yaml
+++ b/policies/vendors/chainguard/chainguard-images-attested-cue.yaml
@@ -27,13 +27,6 @@ spec:
             type: cue
             data: |
               predicateType: "https://spdx.dev/Document"
-        # TODO: uncomment this when we start signing the vuln attestation again
-        # - name: must-have-vuln-attestation-cue
-        #   predicateType: https://cosign.sigstore.dev/attestation/vuln/v1
-        #   policy:
-        #     type: cue
-        #     data: |
-        #       predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
         - name: must-have-provenance-attestation-cue
           predicateType: https://slsa.dev/provenance/v0.2
           policy:


### PR DESCRIPTION
The policy catalog is intended to provide content to copy/paste for external users. Part of this is exposing the content via the Chainguard console. Other organization could choose to do the same as well.

Since we want these policies to be ready to consume, I think it'd be better to not include TODOs, and simply delete the code for now. We can add it back later.