### PR TITLE
fix: tests were expecting an old slsa provenance version

### DIFF
--- a/policies/images/policies_test.go
+++ b/policies/images/policies_test.go
@@ -21,8 +21,8 @@ func TestPolicies(t *testing.T) {
 	}{{
 		name:   "maximum image age",
 		policy: "maximum-image-age-rego.yaml",
-		// This is updated daily.
-		image: "cgr.dev/chainguard/static",
+		// This has been updated recently.
+		image: "cgr.dev/chainguard/nginx",
 		check: All(
 			NoErrors,
 			NoWarnings,

--- a/policies/vendors/chainguard/chainguard-images-attested-cue.yaml
+++ b/policies/vendors/chainguard/chainguard-images-attested-cue.yaml
@@ -28,8 +28,8 @@ spec:
             data: |
               predicateType: "https://spdx.dev/Document"
         - name: must-have-provenance-attestation-cue
-          predicateType: https://slsa.dev/provenance/v0.2
+          predicateType: https://slsa.dev/provenance/v1
           policy:
             type: cue
             data: |
-              predicateType: "https://slsa.dev/provenance/v0.2"
+              predicateType: "https://slsa.dev/provenance/v1"


### PR DESCRIPTION
This is related to the errors seen here: https://github.com/chainguard-dev/policy-catalog/actions/runs/5865462874/job/15902706604?pr=27.